### PR TITLE
Ygg 118/LoginForm 컴포넌트 구현

### DIFF
--- a/components/molecule/FormInput/index.js
+++ b/components/molecule/FormInput/index.js
@@ -2,7 +2,7 @@ import { React } from "react";
 import { StyleSheet, TextInput } from "react-native";
 
 export function FormInput({ error, style, ...props }) {
-    return <TextInput style={[styles.input, error || styles.valueInvalid, style]} {...props} />;
+    return <TextInput style={[styles.input, error && styles.valueInvalid, style]} {...props} />;
 }
 
 const styles = StyleSheet.create({

--- a/components/molecule/FormInput/index.js
+++ b/components/molecule/FormInput/index.js
@@ -1,22 +1,16 @@
 import { React } from "react";
 import { StyleSheet, TextInput } from "react-native";
 
-export function FormInput({ error, ...props }) {
-    return <TextInput style={[styles.input, error ? styles.valueValid : styles.valueInvalid]} {...props} />;
+export function FormInput({ error, style, ...props }) {
+    return <TextInput style={[styles.input, error || styles.valueInvalid, style]} {...props} />;
 }
 
 const styles = StyleSheet.create({
     input: {
-        height: 40,
-        margin: 12,
-        borderWidth: 1,
         padding: 10,
     },
-    valueValid: {
-        borderColor: "black",
-    },
     valueInvalid: {
-        borderColor: "red",
+        color: "red",
     },
 });
 

--- a/components/molecule/FormInput/index.js
+++ b/components/molecule/FormInput/index.js
@@ -1,12 +1,8 @@
-import { React, useState } from "react";
-import { View, StyleSheet, TextInput } from "react-native";
+import { React } from "react";
+import { StyleSheet, TextInput } from "react-native";
 
 export function FormInput({ error, ...props }) {
-    return (
-        <View>
-            <TextInput style={[styles.input, error ? styles.valueValid : styles.valueInvalid]} {...props} />
-        </View>
-    );
+    return <TextInput style={[styles.input, error ? styles.valueValid : styles.valueInvalid]} {...props} />;
 }
 
 const styles = StyleSheet.create({

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -13,12 +13,18 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
         handleSubmit();
     };
 
+    const inputEnd = formData.length - 1;
+
     return (
         <View style={styles.container} {...props}>
             <View style={styles.formBody}>
                 {formData.map(({ name }, index) => (
                     <FormInput
-                        style={[styles.formInput, formData.length == index + 1 && styles.lastInput]}
+                        style={[
+                            styles.formInput,
+                            index == 0 && styles.firstInput,
+                            index == inputEnd && styles.lastInput,
+                        ]}
                         key={name}
                         placeholder={name}
                         value={values[name]}
@@ -56,9 +62,7 @@ const styles = StyleSheet.create({
         justifyContent: "center",
     },
     formBody: {
-        backgroundColor: "white",
         borderRadius: 8,
-        borderWidth: 1,
         borderColor: "#D9D9D9",
         shadowColor: "black",
         elevation: 2,
@@ -66,11 +70,19 @@ const styles = StyleSheet.create({
     formInput: {
         width: 318,
         height: 52,
-        borderBottomWidth: 1,
-        borderBottomColor: "#D9D9D9",
+        borderWidth: 1,
+        borderBottomWidth: 0,
+        borderColor: "#D9D9D9",
+        backgroundColor: "white",
+    },
+    firstInput: {
+        borderTopLeftRadius: 8,
+        borderTopRightRadius: 8,
     },
     lastInput: {
-        borderBottomWidth: 0,
+        borderBottomWidth: 1,
+        borderBottomLeftRadius: 8,
+        borderBottomRightRadius: 8,
     },
     errorMessageView: {
         marginVertical: 6,

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from "react-native";
 import { useState } from "react";
 
 import { useForm } from "hooks";
@@ -51,7 +51,11 @@ export const LoginForm = ({ formData, onSubmit, submitText = "로그인", autoEr
                 disabled={isLoading}
                 onPress={handlePressSubmit}
             >
-                <Text style={styles.buttonText}>{submitText}</Text>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color="gray" />
+                ) : (
+                    <Text style={styles.buttonText}>{submitText}</Text>
+                )}
             </TouchableOpacity>
             <Text style={styles.signupText}>
                 회원이 아니신가요? <Text style={styles.signupLink}>회원가입하기</Text>

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -27,15 +27,14 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
                     />
                 ))}
             </View>
-            <View>
-                {/*error 메시지 출력하는 곳 */}
+            <View style={styles.errorMessageView}>
                 {showError &&
                     formData.map(({ name }) => {
                         const message = errors[name];
                         if (message.length > 0)
                             return (
                                 <Text style={styles.errorMessage} key={name}>
-                                    {message}
+                                    *{message}
                                 </Text>
                             );
                     })}
@@ -67,14 +66,17 @@ const styles = StyleSheet.create({
     formInput: {
         width: 318,
         height: 52,
-        margin: 0,
         borderBottomWidth: 1,
         borderBottomColor: "#D9D9D9",
     },
     lastInput: {
         borderBottomWidth: 0,
     },
+    errorMessageView: {
+        marginVertical: 6,
+    },
     errorMessage: {
+        marginVertical: 2,
         color: "red",
         fontSize: 12,
     },
@@ -83,7 +85,6 @@ const styles = StyleSheet.create({
         alignItems: "center",
         width: 320,
         height: 52,
-        marginVertical: 12,
         borderRadius: 8,
         backgroundColor: "#FF8303",
     },
@@ -91,6 +92,7 @@ const styles = StyleSheet.create({
         color: "white",
     },
     signupText: {
+        marginVertical: 6,
         textAlign: "center",
     },
     signupLink: {

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -1,8 +1,11 @@
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 
+import { useForm } from "hooks";
 import { FormInput } from "molecule";
 
 export const LoginForm = ({ formData, onSubmit, ...props }) => {
+    const { values, errors, isLoading, handleChange, handleSubmit } = useForm(formData, onSubmit);
+
     return (
         <View style={styles.container} {...props}>
             <View style={styles.formBody}>
@@ -11,11 +14,13 @@ export const LoginForm = ({ formData, onSubmit, ...props }) => {
                         style={[styles.formInput, formData.length == index + 1 && styles.lastInput]}
                         key={name}
                         placeholder={name}
-                        error={true}
+                        value={values[name]}
+                        error={errors[name]}
+                        onChangeText={handleChange(name)}
                     />
                 ))}
             </View>
-            <TouchableOpacity style={styles.submitButton}>
+            <TouchableOpacity style={styles.submitButton} disabled={isLoading} onPress={handleSubmit}>
                 <Text style={styles.buttonText}>로그인</Text>
             </TouchableOpacity>
             <Text style={styles.signupText}>

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useForm } from "hooks";
 import { FormInput } from "molecule";
 
-export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...props }) => {
+export const LoginForm = ({ formData, onSubmit, submitText = "로그인", autoErrorDisplay = false, ...props }) => {
     const { values, errors, isLoading, handleChange, handleSubmit } = useForm(formData, onSubmit);
     const [showError, setShowError] = useState(autoErrorDisplay);
 
@@ -51,7 +51,7 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
                 disabled={isLoading}
                 onPress={handlePressSubmit}
             >
-                <Text style={styles.buttonText}>로그인</Text>
+                <Text style={styles.buttonText}>{submitText}</Text>
             </TouchableOpacity>
             <Text style={styles.signupText}>
                 회원이 아니신가요? <Text style={styles.signupLink}>회원가입하기</Text>

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -1,10 +1,17 @@
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useState } from "react";
 
 import { useForm } from "hooks";
 import { FormInput } from "molecule";
 
-export const LoginForm = ({ formData, onSubmit, ...props }) => {
+export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...props }) => {
     const { values, errors, isLoading, handleChange, handleSubmit } = useForm(formData, onSubmit);
+    const [showError, setShowError] = useState(autoErrorDisplay);
+
+    const handlePressSubmitButton = () => {
+        if (!showError) setShowError(true);
+        handleSubmit();
+    };
 
     return (
         <View style={styles.container} {...props}>
@@ -15,12 +22,25 @@ export const LoginForm = ({ formData, onSubmit, ...props }) => {
                         key={name}
                         placeholder={name}
                         value={values[name]}
-                        error={errors[name]}
+                        error={showError && errors[name]}
                         onChangeText={handleChange(name)}
                     />
                 ))}
             </View>
-            <TouchableOpacity style={styles.submitButton} disabled={isLoading} onPress={handleSubmit}>
+            <View>
+                {/*error 메시지 출력하는 곳 */}
+                {showError &&
+                    formData.map(({ name }) => {
+                        const message = errors[name];
+                        if (message.length > 0)
+                            return (
+                                <Text style={styles.errorMessage} key={name}>
+                                    {message}
+                                </Text>
+                            );
+                    })}
+            </View>
+            <TouchableOpacity style={styles.submitButton} disabled={isLoading} onPress={handlePressSubmitButton}>
                 <Text style={styles.buttonText}>로그인</Text>
             </TouchableOpacity>
             <Text style={styles.signupText}>
@@ -53,6 +73,10 @@ const styles = StyleSheet.create({
     },
     lastInput: {
         borderBottomWidth: 0,
+    },
+    errorMessage: {
+        color: "red",
+        fontSize: 12,
     },
     submitButton: {
         justifyContent: "center",

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -8,23 +8,24 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
     const { values, errors, isLoading, handleChange, handleSubmit } = useForm(formData, onSubmit);
     const [showError, setShowError] = useState(autoErrorDisplay);
 
-    const handlePressSubmitButton = () => {
+    const handlePressSubmit = () => {
         if (!showError) setShowError(true);
         handleSubmit();
     };
 
-    const inputEnd = formData.length - 1;
+    const getInputStyle = (index) => {
+        const formInputStyle = [styles.formInput];
+        index == 0 && formInputStyle.push(styles.firstInput);
+        index == formData.length - 1 && formInputStyle.push(styles.lastInput);
+        return formInputStyle;
+    };
 
     return (
         <View style={styles.container} {...props}>
             <View style={styles.formBody}>
                 {formData.map(({ name }, index) => (
                     <FormInput
-                        style={[
-                            styles.formInput,
-                            index == 0 && styles.firstInput,
-                            index == inputEnd && styles.lastInput,
-                        ]}
+                        style={getInputStyle(index)}
                         key={name}
                         placeholder={name}
                         value={values[name]}
@@ -48,7 +49,7 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
             <TouchableOpacity
                 style={[styles.submitButton, isLoading && styles.disabledButton]}
                 disabled={isLoading}
-                onPress={handlePressSubmitButton}
+                onPress={handlePressSubmit}
             >
                 <Text style={styles.buttonText}>로그인</Text>
             </TouchableOpacity>

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -1,0 +1,70 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+import { FormInput } from "molecule";
+
+export const LoginForm = ({ formData, onSubmit, ...props }) => {
+    return (
+        <View style={styles.container} {...props}>
+            <View style={styles.formBody}>
+                {formData.map(({ name }, index) => (
+                    <FormInput
+                        style={[styles.formInput, formData.length == index + 1 && styles.lastInput]}
+                        key={name}
+                        placeholder={name}
+                        error={true}
+                    />
+                ))}
+            </View>
+            <TouchableOpacity style={styles.submitButton}>
+                <Text style={styles.buttonText}>로그인</Text>
+            </TouchableOpacity>
+            <Text style={styles.signupText}>
+                회원이 아니신가요? <Text style={styles.signupLink}>회원가입하기</Text>
+            </Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        width: 320,
+        justifyContent: "center",
+    },
+    formBody: {
+        backgroundColor: "white",
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: "#D9D9D9",
+        shadowColor: "black",
+        elevation: 2,
+    },
+    formInput: {
+        width: 318,
+        height: 52,
+        margin: 0,
+        borderBottomWidth: 1,
+        borderBottomColor: "#D9D9D9",
+    },
+    lastInput: {
+        borderBottomWidth: 0,
+    },
+    submitButton: {
+        justifyContent: "center",
+        alignItems: "center",
+        width: 320,
+        height: 52,
+        marginVertical: 12,
+        borderRadius: 8,
+        backgroundColor: "#FF8303",
+    },
+    buttonText: {
+        color: "white",
+    },
+    signupText: {
+        textAlign: "center",
+    },
+    signupLink: {
+        color: "#FF8303",
+    },
+});

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -45,7 +45,11 @@ export const LoginForm = ({ formData, onSubmit, autoErrorDisplay = false, ...pro
                             );
                     })}
             </View>
-            <TouchableOpacity style={styles.submitButton} disabled={isLoading} onPress={handlePressSubmitButton}>
+            <TouchableOpacity
+                style={[styles.submitButton, isLoading && styles.disabledButton]}
+                disabled={isLoading}
+                onPress={handlePressSubmitButton}
+            >
                 <Text style={styles.buttonText}>로그인</Text>
             </TouchableOpacity>
             <Text style={styles.signupText}>
@@ -99,6 +103,9 @@ const styles = StyleSheet.create({
         height: 52,
         borderRadius: 8,
         backgroundColor: "#FF8303",
+    },
+    disabledButton: {
+        backgroundColor: "#D9D9D9",
     },
     buttonText: {
         color: "white",

--- a/components/organism/index.js
+++ b/components/organism/index.js
@@ -1,0 +1,1 @@
+export { LoginForm } from "./LoginForm/LoginForm.js";

--- a/hooks/useForm.js
+++ b/hooks/useForm.js
@@ -26,8 +26,8 @@ export function useForm(formEntry, onSubmit) {
             [name]: isValid,
         });
         setValues({
-                ...values,
-                [name]: changedValue,
+            ...values,
+            [name]: changedValue,
         });
     };
 
@@ -44,7 +44,7 @@ export function useForm(formEntry, onSubmit) {
         if (hasError) {
             console.log("작성 항목 중 오류가 있습니다!");
         } else {
-            onSubmit();
+            onSubmit(values);
             console.log("제출 완료");
         }
 

--- a/hooks/useForm.js
+++ b/hooks/useForm.js
@@ -1,12 +1,10 @@
 import { useState } from "react";
 
 export function useForm(formEntry, onSubmit) {
-    // 모든 값 초기화인 removeAll이 필요한가?
-    // Submit의 async 필요
-
     const initialValues = {};
     const initialErrors = {};
     const validationCheck = {};
+
     formEntry.forEach(({ name, value, validation }) => {
         initialValues[name] = value;
         initialErrors[name] = true;
@@ -18,7 +16,6 @@ export function useForm(formEntry, onSubmit) {
     const [isLoading, setIsLoading] = useState(false);
 
     const handleChange = (name) => (changedValue) => {
-        // <Input onChangeText={handleChange(name)} /> 과 같이 사용
         const isValid = validationCheck[name](changedValue);
 
         setErrors({
@@ -32,7 +29,6 @@ export function useForm(formEntry, onSubmit) {
     };
 
     const handleSubmit = () => {
-        // API 추가 필요
         let hasError = false;
 
         setIsLoading(true);

--- a/hooks/useForm.js
+++ b/hooks/useForm.js
@@ -33,12 +33,12 @@ export function useForm(formEntry, onSubmit) {
 
     const handleSubmit = () => {
         // API 추가 필요
-        const hasError = false;
+        let hasError = false;
 
         setIsLoading(true);
 
         for (const prop in errors) {
-            if (!prop) hasError = true;
+            if (!errors[prop]) hasError = true;
         }
 
         if (hasError) {

--- a/hooks/useForm.js
+++ b/hooks/useForm.js
@@ -7,7 +7,7 @@ export function useForm(formEntry, onSubmit) {
 
     formEntry.forEach(({ name, value, validation }) => {
         initialValues[name] = value;
-        initialErrors[name] = true;
+        initialErrors[name] = "";
         validationCheck[name] = validation;
     });
 
@@ -16,11 +16,11 @@ export function useForm(formEntry, onSubmit) {
     const [isLoading, setIsLoading] = useState(false);
 
     const handleChange = (name) => (changedValue) => {
-        const isValid = validationCheck[name](changedValue);
+        const errorMessage = validationCheck[name](changedValue);
 
         setErrors({
             ...errors,
-            [name]: isValid,
+            [name]: errorMessage,
         });
         setValues({
             ...values,
@@ -34,11 +34,10 @@ export function useForm(formEntry, onSubmit) {
         setIsLoading(true);
 
         for (const prop in errors) {
-            if (!errors[prop]) hasError = true;
+            if (errors[prop]) hasError = true;
         }
 
         if (hasError) {
-            console.log("작성 항목 중 오류가 있습니다!");
         } else {
             onSubmit(values);
             console.log("제출 완료");


### PR DESCRIPTION
# LoginForm 컴포넌트 구현

![image](https://github.com/Yum-Yogiga/YGG_FE/assets/53640976/e428324c-4381-4190-9560-39a16552c335)

## :bulb: 의도

1. 로그인 창을 위한 레이아웃을 제공합니다
2. formData를 통해 초기값, validation을 입력받고, 
이를 useForm custom hook에 입력해 하위 컴포넌트의 상태 관리에 사용합니다. 

## :bulb: 주요 기능

1. 하위 컴포넌트를 위한 레이아웃, 스타일 제공

- Input 출력 수, 조건부 스타일 등


![errorMessage](https://github.com/Yum-Yogiga/YGG_FE/assets/53640976/a056700f-253b-44a9-bff9-dcc690da0512)

2. 조건부 error message 출력 기능

-별다른 조건이 없다면 제출을 누른 후부터 error message가 보입니다
-autoErrorDisplay를 true로 설정하면 처음부터 입력 오류들이 보입니다


![LoginForm1](https://github.com/Yum-Yogiga/YGG_FE/assets/53640976/6f0c5681-8338-4a39-9221-ad68f427d18e)
3. isLoading이 true일 경우 제출 버튼 비활성화


## :heavy_check_mark: PR 포인트
1. 코드의 가독성이 어떤가요?
2. 로그인창으로서 어떤 기능이 더 추가되면 좋을까요?
3. 제출 버튼이 비활성화 되었을 때 안에 버퍼링 표시를 넣고싶은데 어떤 방법이 있는지 궁금합니다