### PR TITLE
Ygg 135/로그인 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+/assets
 
 # macOS
 .DS_Store

--- a/api/auth.js
+++ b/api/auth.js
@@ -14,3 +14,18 @@ export const signUp = async ({ userId, password, email, nickname }) => {
         console.error("회원가입 API 오류");
     }
 };
+
+export const signIn = async ({ userId, password }) => {
+    const signInInfo = { userId, password };
+
+    try {
+        const { token, refreshToken } = await request("sign-in", {
+            method: "POST",
+            mode: "cors",
+            body: JSON.stringify(signInInfo),
+        });
+        return { token, refreshToken };
+    } catch (e) {
+        console.error("로그인 API 오류");
+    }
+};

--- a/app/Login.js
+++ b/app/Login.js
@@ -1,5 +1,7 @@
 import { LoginForm } from "organism";
-import { styled } from "styled-components";
+import { styled } from "styled-components/native";
+
+import { signIn } from "api";
 
 export default function Login() {
     const logo = require("assets/orange.png");
@@ -21,8 +23,8 @@ export default function Login() {
         },
     ];
 
-    const handleSubmit = () => {
-        console.warn("제출함");
+    const handleSubmit = async (value) => {
+        const response = await signIn(value).then((res) => JSON.stringify(res));
     };
 
     return (

--- a/app/Login.js
+++ b/app/Login.js
@@ -1,0 +1,45 @@
+import { LoginForm } from "organism";
+import { styled } from "styled-components";
+
+export default function Login() {
+    const logo = require("assets/orange.png");
+
+    const formData = [
+        {
+            name: "userId",
+            value: "",
+            validation: (value) => {
+                return "";
+            },
+        },
+        {
+            name: "password",
+            value: "",
+            validation: (value) => {
+                return "";
+            },
+        },
+    ];
+
+    const handleSubmit = () => {
+        console.warn("제출함");
+    };
+
+    return (
+        <Container>
+            <Logo source={logo} />
+            <LoginForm formData={formData} onSubmit={handleSubmit} />
+        </Container>
+    );
+}
+
+const Container = styled.SafeAreaView`
+    align-items: center;
+`;
+
+const Logo = styled.Image.attrs({
+    resizeMode: "center",
+})`
+    max-width: 100%;
+    height: 320px;
+`;

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -1,7 +1,10 @@
 import { useRouter } from "expo-router";
 import { ThemeProvider, DefaultTheme } from "@react-navigation/native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Stack } from "expo-router/stack";
 import { AntDesign } from "@expo/vector-icons";
+
+import { StatusBar, Platform } from "react-native";
 
 const MyTheme = {
     ...DefaultTheme,
@@ -15,28 +18,34 @@ const MyTheme = {
 
 export default function Layout() {
     const router = useRouter();
+
+    const StatusBarHeight = Platform.OS === "ios" ? 0 : StatusBar.currentHeight;
+
     return (
         <ThemeProvider value={MyTheme}>
-            <Stack
-                screenOptions={{
-                    headerStyle: {
-                        backgroundColor: "white",
-                    },
-                    headerLeft: () => (
-                        <AntDesign
-                            name="left"
-                            size={24}
-                            color="black"
-                            onPress={() => {
-                                router.back();
-                            }}
-                        />
-                    ),
-                    title: null,
-                }}
-            >
-                <Stack.Screen name="index" options={{ headerShown: false }} />
-            </Stack>
+            <StatusBar backgroundColor="#FE6E00" />
+            <SafeAreaProvider style={{ paddingTop: StatusBarHeight }}>
+                <Stack
+                    screenOptions={{
+                        headerStyle: {
+                            backgroundColor: "white",
+                        },
+                        headerLeft: () => (
+                            <AntDesign
+                                name="left"
+                                size={24}
+                                color="black"
+                                onPress={() => {
+                                    router.back();
+                                }}
+                            />
+                        ),
+                        title: null,
+                    }}
+                >
+                    <Stack.Screen name="index" options={{ headerShown: false }} />
+                </Stack>
+            </SafeAreaProvider>
         </ThemeProvider>
     );
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,8 @@ module.exports = function (api) {
                         "atom": "./components/atom",
                         "molecule": "./components/molecule",
                         "organism": "./components/organism",
-                        "hooks": "./hooks"
+                        "hooks": "./hooks",
+                        "assets": "./assets"
                     },
                 },
             ],

--- a/components/organism/LoginForm/LoginForm.js
+++ b/components/organism/LoginForm/LoginForm.js
@@ -66,7 +66,6 @@ export const LoginForm = ({ formData, onSubmit, submitText = "로그인", autoEr
 
 const styles = StyleSheet.create({
     container: {
-        flex: 1,
         width: 320,
         justifyContent: "center",
     },


### PR DESCRIPTION
# 로그인 페이지 구현

![image](https://github.com/Yum-Yogiga/YGG_FE/assets/53640976/04abbf60-e998-4c4b-a888-2b6f56b37074)


## :bulb: 의도

1. 로그인 페이지 레이아웃 작성
2. 상단바 및 어플 공통 레이아웃을 위한 _layout.js 작성
3. 페이지에 signIn api 탑재

## :bulb: 주요 기능

의도와 상동
1. 키보드 호출시 안 가려지는 기능은 LoginForm 컴포넌트에서 수정 예정
2. 반환받은 토큰 저장은 별도의 브래치를 팔 예정

## :heavy_check_mark: PR 포인트
